### PR TITLE
Add beforeRestore and afterRestore hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,8 +75,8 @@ export const useStore = defineStore('main', {
     beforeRestore: (context) => {
       console.log('Before hydration...')
     },
-    afterRestore: ({ state }) => {
-      state.lastReload = new Date().toString()
+    afterRestore: ({ store }) => {
+      store.lastReload = new Date().toString()
     }),
   }
 })

--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ In case you want to configure how the data should be persisted, `persist` can ta
 - `storage` : Storage like object to persist state to. Must have `getItem`, `setItem` and `removeItem` methods (defaults to `localStorage`).
 - `paths: Array<string>` : Array of dot-notation paths to partially persist the state, `[]` means no state is persisted (defaults to `undefined` and persists the whole state).
 - `overwrite: boolean` : Whether you want to ovewrite the initial state on hydration (defaults to `false` and [patches](https://pinia.esm.dev/api/interfaces/pinia._StoreWithState.html#patch) the state).
+- `beforeRestore: (context) => void` : Hook executed (if set) _before_ restoring the state from localstorage.
+- `afterRestore: (context) => void` : Hook executed (if set) _after_ restoring the state from localstorage.
 
 
 ```ts
@@ -70,16 +72,52 @@ export const useStore = defineStore('main', {
     storage: window.sessionStorage,
     paths: ['nested.data'],
     overwrite: true,
+    beforeRestore: (context) => {
+      console.log('Before hydration...')
+    },
+    afterRestore: ({ state }) => {
+      state.lastReload = new Date().toString()
+    }),
   }
 })
 ```
 The config above will only persist the `nested.data` property in `sessionStorage` under `storekey` and will overwrite the state on hydration.
 
+It will also execute the `beforeRestore` and `afterRestore` hooks before/after hydration.
+
+## ⚠️ Limitations
+
+__References do not persist__
+
+Beware of the following:
+
+```js
+const a = {
+  1: 'one',
+  2: 'two',
+  ...
+}
+const b = a
+
+// Before hydration 'a' and 'b'
+// point to the same object:
+a === b -> true
+
+// After hydration (page reload)
+// 'a' and 'b' are different objects
+// with the same content:
+a === b -> false
+```
+
+As a consequence, reactivity between _a_ and _b_ is lost.
+
+To get around this you can exclude either _a_ or _b_ from persisting and use the `afterRestore()` hook to populate them after hydration. That way _a_ and _b_ have the same reference again and reactivity is restored after page reload.
+
 ## 🤝 Contributing
 
-This project tries to bring `vuex-persistedstate`'s API to `Pinia` but I did not bring the whole API yet. 
+This project tries to bring `vuex-persistedstate`'s API to `Pinia` but I did not bring the whole API yet.
 
-Run into a problem? Open an [issue](https://github.com/prazdevs/pinia-plugin-persistedstate/issues/new/choose).  
+Run into a problem? Open an [issue](https://github.com/prazdevs/pinia-plugin-persistedstate/issues/new/choose).
 Want to add some feature? PRs are welcome!
 
 ## 👤 About the author

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,6 +28,17 @@ export interface PersistedStateOptions {
    * @default false
    */
   overwrite?: boolean
+
+  /**
+   * Hook called before state is hydrated from storage.
+   * @default undefined
+   */
+  beforeRestore?: (context: PiniaPluginContext) => void
+
+  /**
+   * Hook called after state is hydrated from storage.
+   */
+  afterRestore?: (context: PiniaPluginContext) => void
 }
 
 /* c8 ignore next 11 */
@@ -55,7 +66,11 @@ export default function (context: PiniaPluginContext): void {
     key = store.$id,
     paths = null,
     overwrite = false,
+    beforeRestore = null,
+    afterRestore = null,
   } = typeof persist != 'boolean' ? persist : {}
+
+  beforeRestore?.(context)
 
   try {
     const fromStorage = storage.getItem(key)
@@ -64,6 +79,8 @@ export default function (context: PiniaPluginContext): void {
       else store.$patch(JSON.parse(fromStorage))
     }
   } catch (_error) {}
+
+  afterRestore?.(context)
 
   store.$subscribe((_mutation: unknown, state: unknown) => {
     try {

--- a/tests/index.spec.ts
+++ b/tests/index.spec.ts
@@ -216,3 +216,39 @@ describe('w/ storage', () => {
     expect(storage.getItem).toHaveBeenCalled()
   })
 })
+
+/**
+ * Test `beforeRestore` and `afterRestore` function call execution if set.
+ */
+describe('beforeRestore and afterRestore', () => {
+  const useStore = defineStore(key, {
+    state: () => ({
+      lorem: '',
+      before: '',
+      after: '',
+    }),
+    persist: {
+      beforeRestore: vi.fn(ctx => {
+        ctx.store.before = 'before'
+      }),
+      afterRestore: vi.fn(ctx => {
+        ctx.store.after = 'after'
+      }),
+    },
+  })
+
+  it('rehydrates store from localStorage', async () => {
+    //* arrange
+    initializeLocalStorage(key, { lorem: 'ipsum' })
+
+    //* act
+    await nextTick()
+    const store = useStore()
+
+    //* assert
+    expect(store.lorem).toEqual('ipsum')
+    expect(localStorage.getItem).toHaveBeenCalledWith(key)
+    expect(store.before).toEqual('before')
+    expect(store.after).toEqual('after')
+  })
+})


### PR DESCRIPTION
- Adds `beforeRestore` and `afterRestore` hooks to execute code before/after hydration.
- Includes test for the above.
- Adds hooks description and "Limitations" section with entry regarding references to the README.