### PR TITLE
Subscribe to pinia state changes in detached mode.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pinia-plugin-persistedstate",
-  "version": "1.2.3",
+  "version": "1.2.2",
   "description": "Configurable persistence and rehydration of Pinia stores.",
   "keywords": [
     "pinia-plugin"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pinia-plugin-persistedstate",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "Configurable persistence and rehydration of Pinia stores.",
   "keywords": [
     "pinia-plugin"

--- a/src/index.ts
+++ b/src/index.ts
@@ -89,5 +89,5 @@ export default function (context: PiniaPluginContext): void {
 
       storage.setItem(key, JSON.stringify(toStore))
     } catch (_error) {}
-  })
+  }, { detached: true })
 }


### PR DESCRIPTION
Fix for Issue #23 

When the plugin subscribes to pinia state changes, it should pass `{ detached: true }` to subscribe.  Otherwise pinia tries to tie the subscription to a component's lifetime, and remove the subscription when the component is unmounted.  For this plugin, the subscription should not be tied to any component's lifetime.  See here in the Pinia documentation for information about this option.

https://pinia.vuejs.org/core-concepts/state.html#subscribing-to-the-state

The symptom I get without this change, is a warning in the browser like this:

> [Vue warn]: onUnmounted is called when there is no active component instance to be associated with. Lifecycle injection APIs can only be used during execution of setup(). If you are using async setup(), make sure to register lifecycle hooks before the first await statement.

This is with vue 3.2.31.