### PR TITLE
feat: add method to manually restore state

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,8 @@ The config above will only persist the `nested.data` property in `sessionStorage
 
 It will also execute the `beforeRestore` and `afterRestore` hooks respectively _before_ and _after_ hydration.
 
+In case you want to restore state manually, you can use `$restoreManually` method
+
 ### Usage with Nuxt
 
 Declare a [Nuxt Plugin](https://v3.nuxtjs.org/docs/directory-structure/plugins) to add the plugin to Pinia.

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,8 +10,9 @@ declare module 'pinia' {
   }
   export interface PiniaCustomProperties {
     /**
-     * Restore state manually.
-     * @docs https://github.com/prazdevs/pinia-plugin-persistedstate.
+     * @
+     * Forces the pinia store to be rehydrated with stored data.
+     * Warning: this shouldn't be used in most cases
      */
     $restoreManually: () => void
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,13 @@ declare module 'pinia' {
      */
     persist?: boolean | PersistedStateOptions
   }
+  export interface PiniaCustomProperties {
+    /**
+     * Restore state manually.
+     * @docs https://github.com/prazdevs/pinia-plugin-persistedstate.
+     */
+    $restoreManually: () => void
+  }
 }
 
 export type {

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -35,14 +35,18 @@ export function createPersistedState(
       paths = null,
     } = normalizeOptions(persist, factoryOptions)
 
-    beforeRestore?.(context)
+    store.$restoreManually = () => {
+      beforeRestore?.(context)
 
-    try {
-      const fromStorage = storage.getItem(key)
-      if (fromStorage) store.$patch(serializer.deserialize(fromStorage))
-    } catch (_error) {}
+      try {
+        const fromStorage = storage.getItem(key)
+        if (fromStorage) store.$patch(serializer.deserialize(fromStorage))
+      } catch (_error) {}
 
-    afterRestore?.(context)
+      afterRestore?.(context)
+    }
+
+    store.restoreManually()
 
     store.$subscribe(
       (

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -46,7 +46,7 @@ export function createPersistedState(
       afterRestore?.(context)
     }
 
-    store.restoreManually()
+    store.$restoreManually()
 
     store.$subscribe(
       (

--- a/tests/plugin.spec.ts
+++ b/tests/plugin.spec.ts
@@ -133,6 +133,23 @@ describe('default export', () => {
       )
     })
 
+    it('restore manually', async () => {
+      //* arrange
+      const store = useStore()
+
+      //* act
+      localStorage.setItem(key, JSON.stringify({ lorem: 'ipsum' }))
+      await nextTick()
+
+      //* assert
+      expect(store.lorem).toEqual('')
+
+      store.$restoreManually()
+      await nextTick()
+
+      expect(store.lorem).toEqual('ipsum')
+    })
+
     it('rehydrates store from localStorage', async () => {
       //* arrange
       initializeLocalStorage(key, { lorem: 'ipsum' })


### PR DESCRIPTION
<!-- DO NOT INGORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description
Currently, there is no way to restore the state. It is automatically restored when the page is reloaded, but if used storage is modified somehow, it can't be restored again. This pr adds a `$restoreManually` method to solve this issue

### Linked Issues
#87 

### Additional context
The function name may be changed
