### PR TITLE
feat: split to multiple cookies & support for other storage options

### DIFF
--- a/src/nuxt.ts
+++ b/src/nuxt.ts
@@ -1,14 +1,12 @@
-import { useCookie, CookieOptions } from 'nuxt/app'
+import { CookieOptions } from 'nuxt/app'
 
 import { createPersistedState } from '~/core/plugin'
 import { PersistedStateFactoryOptions } from '~/core/types'
 
-type UseCookie = typeof useCookie
-
 export type PersistedStateNuxtFactoryOptions = Omit<
   PersistedStateFactoryOptions,
   'storage'
-> & { cookieOptions?: CookieOptions<string> }
+> & { cookieOptions?: CookieOptions<string> } & { splitCookies: number }
 
 /**
  * Creates a Nuxt-specific SSR-ready pinia persistence plugin based on cookies
@@ -16,25 +14,46 @@ export type PersistedStateNuxtFactoryOptions = Omit<
  * @param factoryOptions global persistence options
  * @returns pinia plugin
  */
+
+interface UseCookie {
+  get: (key: string) => string | undefined
+  set: (key: string, value: string, options?: CookieOptions<string>) => void
+}
+
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 export function createNuxtPersistedState(
   useCookie: UseCookie,
   factoryOptions?: PersistedStateNuxtFactoryOptions,
 ) {
+  const handleCookie = (
+    data: UseCookie['get'] | UseCookie['set'],
+    key: string,
+    value = '',
+    cookie = '',
+  ) => {
+    const numberOfCookies = factoryOptions?.splitCookies
+      ? factoryOptions?.splitCookies
+      : 1
+    for (let i = 0; i < numberOfCookies; i++)
+      if (value) {
+        const length = Math.ceil(value.length / numberOfCookies)
+        const start = i * length
+        const end = start + length
+        data(key + (i || ''), value.toString().substring(start, end), {
+          ...factoryOptions?.cookieOptions,
+        })
+        // @ts-ignore
+      } else cookie += data(key + (i || ''))
+
+    return cookie
+  }
   return createPersistedState({
     storage: {
       getItem: key => {
-        return useCookie(key, {
-          encode: encodeURIComponent,
-          decode: decodeURIComponent,
-          ...factoryOptions?.cookieOptions,
-        }).value
+        return handleCookie(useCookie.get, key)
       },
       setItem: (key, value) => {
-        useCookie(key, {
-          encode: encodeURIComponent,
-          decode: decodeURIComponent,
-          ...factoryOptions?.cookieOptions,
-        }).value = value
+        handleCookie(useCookie.set, key, value)
       },
     },
     ...factoryOptions,


### PR DESCRIPTION
added support to split into multiple cookies & all storage driver that support get() & set()
    
    -  BREAKING CHANGE: removed support for useCookie
    -  RECOMMENDED ALTERNATIVE: cookie-universal or js-cookie


fixes: https://github.com/prazdevs/pinia-plugin-persistedstate/issues/84

a step closer to fixing: https://github.com/prazdevs/pinia-plugin-persistedstate/issues/77
see https://github.com/prazdevs/pinia-plugin-persistedstate/issues/97#issuecomment-1207200551
for more info

## Description

Added an option to split the cookies to multiple cookies.
Changed syntax similar to storage.get() storage.set()

Use https://github.com/microcipcip/cookie-universal/tree/master/packages/cookie-universal
to persist cookie changes from SSR to client

or js-cookie for client only persistence in cookie


use it like so
<img width="627" alt="image" src="https://user-images.githubusercontent.com/3810177/183248351-d86e7186-038d-4cf9-8f81-e36e6ba6f032.png">
