### PR TITLE
✨ Introduce `paths`-option Syntax to specify Array Content Persistance

### DIFF
--- a/docs/guide/config.md
+++ b/docs/guide/config.md
@@ -102,7 +102,7 @@ export const useStore = defineStore('store', {
 In this store, only `save.me` and `saveMeToo` values will be persisted. `save.notMe` will not be persisted.
 :::
 
-To store all contents of an array, use the notation `'[]'`.
+To store all elements of an array, use the notation `'[]'`.
 
 :::details Example
 ```ts

--- a/docs/guide/config.md
+++ b/docs/guide/config.md
@@ -102,6 +102,29 @@ export const useStore = defineStore('store', {
 In this store, only `save.me` and `saveMeToo` values will be persisted. `save.notMe` will not be persisted.
 :::
 
+To store all contents of an array, use the notation `'[]'`.
+
+:::details Example
+```ts
+import { defineStore } from 'pinia'
+
+export const useStore = defineStore('store', {
+  state: () => ({
+    save: [
+      { me: 'saved', ignored: 'ignored' }
+      { me: 'saved-too', value: 'ignored-too' }
+      { me: 'saved-as-well', test: 'ignored-as-well' }
+    ],
+  }),
+  persist: {
+    paths: ['save.[].me'],
+  },
+})
+```
+
+In this store, only `save[0].me`, `save[1].me` and `save[2].me` values will be persisted.
+:::
+
 ## serializer
 
 - **type**: [`Serializer`](https://github.com/prazdevs/pinia-plugin-persistedstate/blob/main/src/core/types.ts#L5)

--- a/src/core/pick.ts
+++ b/src/core/pick.ts
@@ -1,24 +1,134 @@
 import type { StateTree } from 'pinia'
+import type { Mergeable } from '~/core/types'
+
+function merge(destination: Mergeable, source: Mergeable): Mergeable {
+  const mergingArrays = Array.isArray(destination) && Array.isArray(source)
+  const mergingObjects =
+    typeof destination === 'object' &&
+    typeof source === 'object' &&
+    destination !== null &&
+    source !== null
+
+  if (!mergingArrays && !mergingObjects) {
+    throw new Error('Can only merge object with object or array with array')
+  }
+
+  const result = (mergingArrays ? [] : {}) as Mergeable
+
+  const keys: string[] = [...Object.keys(destination), ...Object.keys(source)]
+  keys.forEach((key: string) => {
+    if (Array.isArray(destination[key]) && Array.isArray(source[key])) {
+      return (result[key] = [
+        ...Object.values(
+          merge(destination[key] as Mergeable, source[key] as Mergeable),
+        ),
+      ])
+    }
+
+    if (
+      source[key] !== null &&
+      typeof source[key] === 'object' &&
+      typeof destination[key] === 'object'
+    ) {
+      return (result[key] = merge(
+        destination[key] as Mergeable,
+        source[key] as Mergeable,
+      ))
+    }
+
+    if (destination[key] !== undefined && source[key] === undefined) {
+      return (result[key] = destination[key])
+    }
+
+    if (destination[key] === undefined && source[key] !== undefined) {
+      return (result[key] = source[key])
+    }
+  })
+
+  return result
+}
 
 function get(state: StateTree, path: Array<string>): unknown {
   return path.reduce((obj, p) => {
+    if (p === '[]' && Array.isArray(obj)) return obj
     return obj?.[p]
   }, state)
 }
 
 function set(state: StateTree, path: Array<string>, val: unknown): StateTree {
-  return (
-    (path.slice(0, -1).reduce((obj, p) => {
-      if (!/^(__proto__)$/.test(p)) return (obj[p] = obj[p] || {})
-      else return {}
-    }, state)[path[path.length - 1]] = val),
-    state
-  )
+  const modifiedState = path.slice(0, -1).reduce((obj, p) => {
+    if (!/^(__proto__)$/.test(p)) return (obj[p] = obj[p] || {})
+    else return {}
+  }, state)
+
+  if (
+    Array.isArray(modifiedState[path[path.length - 1]]) &&
+    Array.isArray(val)
+  ) {
+    const merged = modifiedState[path[path.length - 1]].map(
+      (item: Mergeable, index: number) => {
+        if (Array.isArray(item) && typeof item !== 'object') {
+          return [...item, ...val[index]]
+        }
+
+        if (
+          typeof item === 'object' &&
+          item !== null &&
+          Object.keys(item).some(key => Array.isArray(item[key]))
+        ) {
+          return merge(item, val[index])
+        }
+
+        return {
+          ...item,
+          ...val[index],
+        }
+      },
+    )
+    modifiedState[path[path.length - 1]] = merged
+  } else if (
+    path[path.length - 1] === undefined &&
+    Array.isArray(modifiedState) &&
+    Array.isArray(val)
+  ) {
+    modifiedState.push(...val)
+  } else {
+    modifiedState[path[path.length - 1]] = val
+  }
+
+  return state
 }
 
 export default function pick(baseState: StateTree, paths: string[]): StateTree {
-  return paths.reduce<StateTree>((substate, path) => {
-    const pathArray = path.split('.')
-    return set(substate, pathArray, get(baseState, pathArray))
-  }, {})
+  return paths.reduce<StateTree>(
+    (substate, path) => {
+      const pathArray = path.split('.')
+      if (!pathArray.includes('[]')) {
+        return set(substate, pathArray, get(baseState, pathArray))
+      }
+      const arrayIndex = pathArray.indexOf('[]')
+      const pathArrayBeforeArray = pathArray.slice(0, arrayIndex)
+      const pathArrayUntilArray = pathArray.slice(0, arrayIndex + 1)
+      const pathArrayAfterArray = pathArray.slice(arrayIndex + 1)
+      const referencedArray = get(
+        baseState,
+        pathArrayUntilArray,
+      ) as Array<StateTree>
+      const referencedArraySubstate = []
+      for (const item of referencedArray) {
+        if (
+          pathArrayAfterArray.length !== 0 &&
+          (Array.isArray(item) || typeof item === 'object')
+        ) {
+          referencedArraySubstate.push(
+            pick(item, [pathArrayAfterArray.join('.')]),
+          )
+        } else {
+          referencedArraySubstate.push(item)
+        }
+      }
+      return set(substate, pathArrayBeforeArray, referencedArraySubstate)
+    },
+    Array.isArray(baseState) ? [] : {},
+  )
 }

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -53,10 +53,6 @@ export interface PersistedStateOptions {
   afterRestore?: (context: PiniaPluginContext) => void
 }
 
-export type Mergeable = {
-  [key: string]: unknown
-}
-
 export type PersistedStateFactoryOptions = Pick<
   PersistedStateOptions,
   'storage' | 'serializer' | 'afterRestore' | 'beforeRestore'

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -53,6 +53,10 @@ export interface PersistedStateOptions {
   afterRestore?: (context: PiniaPluginContext) => void
 }
 
+export type Mergeable = {
+  [key: string]: unknown
+}
+
 export type PersistedStateFactoryOptions = Pick<
   PersistedStateOptions,
   'storage' | 'serializer' | 'afterRestore' | 'beforeRestore'

--- a/tests/pick.spec.ts
+++ b/tests/pick.spec.ts
@@ -41,3 +41,56 @@ it('creates paths for undefined values', () => {
   //* assert
   expect(result).to.eql({ not: { defined: { yet: undefined } } })
 })
+
+it('picks child-properties from all of an arrays elements', () => {
+  //* arrange
+  const object = {
+    array: [
+      { picked: 'picked0', value: 'value0', ignored: 'ignored0' },
+      { picked: 'picked1', value: 'value1', ignored: 'ignored1' },
+    ],
+    secondArray: [{ hello: 'world' }, { hi: 'planet' }],
+  }
+
+  //* act
+  const result = pick(object, [
+    'array.[].picked',
+    'array.[].value',
+    'secondArray.[]',
+  ])
+
+  //* assert
+  expect(result).to.eql({
+    array: [
+      { picked: 'picked0', value: 'value0' },
+      { picked: 'picked1', value: 'value1' },
+    ],
+    secondArray: [{ hello: 'world' }, { hi: 'planet' }],
+  })
+})
+
+it('picks all elements from multiple nested arrays', () => {
+  //* arrange
+  const object = {
+    array1: [
+      [['picked0', 'picked1', { picked2: 'picked2' }]],
+      [['picked3', { picked4: 'picked4', picked5: 'picked5' }, 'picked6']],
+    ],
+    array2: [
+      [{ picked: 'picked0', ignored: 'ignored0' }],
+      [{ picked: 'picked1', ignored: 'ignored1' }],
+    ],
+  }
+
+  //* act
+  const result = pick(object, ['array1.[].[].[]', 'array2.[].[].picked'])
+
+  //* assert
+  expect(result).to.eql({
+    array1: [
+      [['picked0', 'picked1', { picked2: 'picked2' }]],
+      [['picked3', { picked4: 'picked4', picked5: 'picked5' }, 'picked6']],
+    ],
+    array2: [[{ picked: 'picked0' }], [{ picked: 'picked1' }]],
+  })
+})


### PR DESCRIPTION
## Description

Enables developers to use `'[]'` in the [`paths`-option](https://prazdevs.github.io/pinia-plugin-persistedstate/guide/config.html#paths), to specify the persistance of all of an arrays contents.

Example:

```ts
import { defineStore } from 'pinia'

export const useStore = defineStore('store', {
  state: () => ({
    save: [
      { me: 'saved', ignored: 'ignored' }
      { me: 'saved-too', value: 'ignored-too' }
      { me: 'saved-as-well', test: 'ignored-as-well' }
    ],
  }),
  persist: {
    paths: ['save.[].me'],
  },
})
```

In this store, only `save[0].me`, `save[1].me` and `save[2].me` values will be persisted.

## Linked Issues

implements https://github.com/prazdevs/pinia-plugin-persistedstate/issues/116
