### PR TITLE
Add error message printing

### DIFF
--- a/src/core/plugin.ts
+++ b/src/core/plugin.ts
@@ -85,7 +85,9 @@ export function createPersistedState(
             const toStore = Array.isArray(paths) ? pick(state, paths) : state
 
             storage.setItem(key, serializer.serialize(toStore as StateTree))
-          } catch (_error) {}
+          } catch (_error) {
+            console.log(_error)
+          }
         },
         {
           detached: true,


### PR DESCRIPTION
It is necessary to print the error message. Pinia-plugin-persistedstate failed to write to the localstorage because of the hidden object circular reference, but there is no error message on the console. It took me one day to find the cause.😂

<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/prazdevs/pinia-plugin-persistedstate/blob/main/CONTRIBUTING.md).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

## Description

It is necessary to print the error message. Pinia-plugin-persistedstate failed to write to the localstorage because of the hidden object circular reference, but there is no error message on the console. It took me one day to find the cause.😂

## Linked Issues

<!-- Reference the issues this PR solves -->


## Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
