### PR TITLE
:sparkles: add error logging with `debug` option

### DIFF
--- a/docs/guide/config.md
+++ b/docs/guide/config.md
@@ -212,3 +212,10 @@ This store will log `just restored 'store'` _after_ being rehydrated.
 :::warning
 Beware of interacting with `PiniaPluginContext`, unexpected behaviors may occur.
 :::
+
+## debug
+
+- **type**: `boolean`
+- **default**: `false`
+
+When set to true, any error that may occur while persisting/hydrating stores will be logged as `console.error`.

--- a/src/core/plugin.ts
+++ b/src/core/plugin.ts
@@ -19,11 +19,14 @@ function hydrateStore(
   storage: StorageLike,
   serializer: Serializer,
   key: string,
+  debug: boolean,
 ) {
   try {
     const fromStorage = storage?.getItem(key)
     if (fromStorage) store.$patch(serializer?.deserialize(fromStorage))
-  } catch (_error) {}
+  } catch (error) {
+    if (debug) console.error(error)
+  }
 }
 
 /**
@@ -82,7 +85,7 @@ export function createPersistedState(
 
       beforeRestore?.(context)
 
-      hydrateStore(store, storage, serializer, key)
+      hydrateStore(store, storage, serializer, key, debug)
 
       afterRestore?.(context)
 
@@ -106,12 +109,13 @@ export function createPersistedState(
     })
 
     store.$hydrate = ({ runHooks = true } = {}) => {
-      persistences.forEach(p => {
-        const { beforeRestore, afterRestore, storage, serializer, key } = p
+      persistences.forEach(persistence => {
+        const { beforeRestore, afterRestore, storage, serializer, key, debug } =
+          persistence
 
         if (runHooks) beforeRestore?.(context)
 
-        hydrateStore(store, storage, serializer, key)
+        hydrateStore(store, storage, serializer, key, debug)
 
         if (runHooks) afterRestore?.(context)
       })

--- a/src/core/plugin.ts
+++ b/src/core/plugin.ts
@@ -57,6 +57,7 @@ export function createPersistedState(
         },
         key = store.$id,
         paths = null,
+        debug = false,
       }) => ({
         storage,
         beforeRestore,
@@ -64,11 +65,20 @@ export function createPersistedState(
         serializer,
         key,
         paths,
+        debug,
       }),
     )
 
-    persistences.forEach(p => {
-      const { storage, serializer, key, paths, beforeRestore, afterRestore } = p
+    persistences.forEach(persistence => {
+      const {
+        storage,
+        serializer,
+        key,
+        paths,
+        beforeRestore,
+        afterRestore,
+        debug,
+      } = persistence
 
       beforeRestore?.(context)
 
@@ -85,8 +95,8 @@ export function createPersistedState(
             const toStore = Array.isArray(paths) ? pick(state, paths) : state
 
             storage.setItem(key, serializer.serialize(toStore as StateTree))
-          } catch (_error) {
-            console.log(_error)
+          } catch (error) {
+            if (debug) console.error(error)
           }
         },
         {

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -51,11 +51,17 @@ export interface PersistedStateOptions {
    * @default undefined
    */
   afterRestore?: (context: PiniaPluginContext) => void
+
+  /**
+   * Logs errors in console when enabled.
+   * @default false
+   */
+  debug?: boolean
 }
 
 export type PersistedStateFactoryOptions = Pick<
   PersistedStateOptions,
-  'storage' | 'serializer' | 'afterRestore' | 'beforeRestore'
+  'storage' | 'serializer' | 'afterRestore' | 'beforeRestore' | 'debug'
 >
 
 declare module 'pinia' {


### PR DESCRIPTION
## Description

Logs errors as `console.error` when `debug` is set to `true`.