### PR TITLE
Feature: Add option 'keyPrefix'

### DIFF
--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -18,6 +18,12 @@ export interface Serializer {
 
 export interface PersistedStateOptions {
   /**
+   * Prefix to use for storage keys.
+   * @default undefined
+   */
+  keyPrefix?: string
+
+  /**
    * Storage key to use.
    * @default $store.id
    */

--- a/tests/plugin.spec.ts
+++ b/tests/plugin.spec.ts
@@ -196,6 +196,42 @@ describe('default', () => {
     })
   })
 
+  describe('w/ keyPrefix', () => {
+    const useStore = defineStore(key, {
+      state: () => ({ lorem: '' }),
+      persist: { keyPrefix: 'prefixed-' },
+    })
+
+    it('persists store in localStorage under given key', async () => {
+      //* arrange
+      const store = useStore()
+
+      //* act
+      store.lorem = 'ipsum'
+      await nextTick()
+
+      //* assert
+      expect(readLocalStoage(`prefixed-${key}`)).toEqual({ lorem: 'ipsum' })
+      expect(localStorage.setItem).toHaveBeenCalledWith(
+        'prefixed-mock-store',
+        JSON.stringify({ lorem: 'ipsum' }),
+      )
+    })
+
+    it('rehydrates store from localStorage under given key', async () => {
+      //* arrange
+      initializeLocalStorage('prefixed-mock-store', { lorem: 'ipsum' })
+
+      //* act
+      await nextTick()
+      const store = useStore()
+
+      //* assert
+      expect(store.lorem).toEqual('ipsum')
+      expect(localStorage.getItem).toHaveBeenCalledWith('prefixed-mock-store')
+    })
+  })
+
   describe('w/ paths', () => {
     const useStore = defineStore(key, {
       state: () => ({


### PR DESCRIPTION
## Description

When using this plugin on a domain that contains localstorage keys from other apps/sources it would be nice to be able to easily prefix all the keys created by this plugin.
It can already be done by manually by setting the `key` option on every Pinia store you define.
This PR adds the option `keyPrefix` so that you can set a default prefix to be used for all the stores you define.

## Linked Issues

#62 

## Additional context

I used this concept to concatenate the `keyPrefix` and `key` in each place:
```
[keyPrefix, key].filter(Boolean).join('')
```
Maybe it should be extracted to a utility function for better readability.

I also thought of using `''` (empty string) as default value for `keyPrefix` so I could instead just do
```
keyPrefix + key
```
for concatenation, but opted for `undefined` as default value instead.
