### PR TITLE
✨ Added trigger points for updating the storage

### DIFF
--- a/docs/guide/advanced.md
+++ b/docs/guide/advanced.md
@@ -16,16 +16,26 @@ const pinia = createPinia()
 
 pinia.use(createPersistedState({
   storage: sessionStorage,
+  key: ( { $id } ) => `_persist_${$id}`
 }))
 ```
 
 In this example, every store declaring `persist: true` will by default persist data to `sessionStorage`.
 
 Available global options include:
+- `key`
 - [`storage`](/guide/config#storage)
 - [`serializer`](/guide/config#serializer)
 - [`beforeRestore`](/guide/config#beforeRestore)
 - [`afterRestore`](/guide/config#afterRestore)
+<br>
+<br>
+### Global `key` option
+- **type**: `(store: PiniaPluginContext['store']) => string`
+- **default**: `undefined`.
+
+A global method to set keys for any store persistence. Useful to prefix the name of the key of each persistence of any store.
+
 
 :::info
 Any option passed to a store's `persist` configuration will override its counterpart declared in the global options.
@@ -112,3 +122,29 @@ This will fetch data from the storage and replace the current state with it. In 
 :::warning
 In most cases, you should not need to manually hydrate the state. Make sure you know what you are doing, and the reason you are using `$hydrate` is not due to a bug (of either your implementation or the plugin itself).
 :::
+
+## Manually persist state
+
+In case you need to manually persist the data in the storage, you can access the method in the `$persist` object available in the store.
+
+```ts
+import { defineStore } from 'pinia'
+
+defineStore('store', {
+  state: () => ({
+    someData: 'Hello Pinia'
+  }),
+  action: {
+    updateSomeData( newValue ) {
+      this.someData = newValue;
+
+      this.$persist.updateInStorage();
+    }
+  },
+  persist: {
+    updationTriggers: []
+  },
+})
+```
+
+When there are multiple persistences then you will need to pass the index of the persistence you want to update.

--- a/docs/guide/config.md
+++ b/docs/guide/config.md
@@ -67,12 +67,30 @@ export const useStore = defineStore('store', {
 })
 ```
 
-This store will be persisted in [`sessionStorage`](https://developer.mozilla.org/en-US/docs/Web/API/Window/sessionStorage).
-:::
+## updationTriggers
 
-:::warning
-Storage must be synchronous. More info in the [limitations page](/guide/limitations).
-:::
+- **type**: [`Array<'subscribe' | 'beforeunload'>`]
+- **default**: [`['subscribe']`]
+
+When the data will actually be put in storage. 
+1. `subscribe`: implies that the data will be updated in storage on every `$subscribe` of the store. 
+2. `beforeunload`: implies that the data will only be updated in storage when the browser tab is refreshed/killed.
+
+Prefer manual updation using `$persist.updateInStorage` instead of `subscribe` when the store is being updated at high frequency
+
+:::details Example
+```ts
+import { defineStore } from 'pinia'
+
+export const useStore = defineStore('store', {
+  state: () => ({
+    someState: 'hello pinia',
+  }),
+  persist: {
+    updationTriggers: [ 'beforeunload' ]
+  },
+})
+```
 
 ## paths
 

--- a/src/core/normalize.ts
+++ b/src/core/normalize.ts
@@ -10,11 +10,16 @@ function isObject(v: unknown) {
 export default function normalizeOptions(
   options: boolean | PersistedStateOptions | undefined,
   factoryOptions: PersistedStateFactoryOptions,
+  globalOrDefaultKey?: string,
 ): PersistedStateOptions {
   options = isObject(options) ? options : Object.create(null)
 
   return new Proxy(options as object, {
     get(target, key, receiver) {
+      if (key === 'key') {
+        return Reflect.get(target, key, receiver) || globalOrDefaultKey
+      }
+
       return (
         Reflect.get(target, key, receiver) ||
         Reflect.get(factoryOptions, key, receiver)

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -57,12 +57,26 @@ export interface PersistedStateOptions {
    * @default false
    */
   debug?: boolean
+
+  /**
+   * Defines at what points can the storage be updated. 'subscribe' happens on every $subscribe
+   * of the store and 'beforeunload' happens before browser tab close/refresh
+   * @default ['subscribe']
+   */
+  updationTriggers?: Array<'subscribe' | 'beforeunload'>
 }
 
-export type PersistedStateFactoryOptions = Pick<
-  PersistedStateOptions,
-  'storage' | 'serializer' | 'afterRestore' | 'beforeRestore' | 'debug'
->
+export interface PersistedStateFactoryOptions
+  extends Pick<
+    PersistedStateOptions,
+    'storage' | 'serializer' | 'afterRestore' | 'beforeRestore' | 'debug'
+  > {
+  /**
+   * Storage key to globally for all modules. Priority will be given to store level key in `persist`
+   * @default undefined
+   */
+  key?: (store: PiniaPluginContext['store']) => string
+}
 
 declare module 'pinia' {
   export interface DefineStoreOptionsBase<S extends StateTree, Store> {
@@ -80,5 +94,15 @@ declare module 'pinia' {
      * @see https://github.com/prazdevs/pinia-plugin-persistedstate
      */
     $hydrate: (opts?: { runHooks?: boolean }) => void
+
+    $persist: {
+      /**
+       * Manually updates storage whenever called for the store
+       * @see https://github.com/prazdevs/pinia-plugin-persistedstate
+       */
+      updateInStorage: (persistanceIndex?: number) => void
+    }
   }
 }
+
+export type PersistanceStorageUpdater = (state: StateTree) => void

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,19 @@
+export const consoleError: typeof console.error = (...args) => {
+  console.error('[PiniaPluginPersistedState] ', ...args)
+}
+
+export function safeAttachWindowEvent(
+  eventName: keyof WindowEventMap,
+  handler: EventListener,
+  { debug }: { debug: boolean },
+): void {
+  const canAttachEvent = window && 'addEventListener' in window
+
+  if (!canAttachEvent) {
+    if (debug) consoleError('Cannot attach "beforeunload" event to window')
+
+    return
+  }
+
+  window.addEventListener(eventName, handler)
+}

--- a/tests/plugin.spec.ts
+++ b/tests/plugin.spec.ts
@@ -3,7 +3,7 @@ import { describe, beforeEach, it, expect, vi, beforeAll } from 'vitest'
 import { createApp, nextTick, Vue2, isVue2, install, ref } from 'vue-demi'
 
 import { createPersistedState } from '~/core/plugin'
-import { initializeLocalStorage, readLocalStoage } from '~~/tests/utils'
+import { initializeLocalStorage, readLocalStorage } from '~~/tests/utils'
 
 const key = 'mock-store'
 
@@ -48,13 +48,12 @@ describe('default', () => {
     it('does not persist store', async () => {
       //* arrange
       const store = useStore()
-
       //* act
       store.lorem = 'ipsum'
       await nextTick()
 
       //* assert
-      expect(readLocalStoage(key)).toEqual({})
+      expect(readLocalStorage(key)).toEqual({})
       expect(localStorage.setItem).not.toHaveBeenCalled()
     })
 
@@ -87,7 +86,7 @@ describe('default', () => {
       await nextTick()
 
       //* assert
-      expect(readLocalStoage(key)).toEqual({ lorem: 'ipsum' })
+      expect(readLocalStorage(key)).toEqual({ lorem: 'ipsum' })
       expect(localStorage.setItem).toHaveBeenCalledWith(
         key,
         JSON.stringify({ lorem: 'ipsum' }),
@@ -122,7 +121,7 @@ describe('default', () => {
       await nextTick()
 
       //* assert
-      expect(readLocalStoage(key)).toEqual({ lorem: 'ipsum' })
+      expect(readLocalStorage(key)).toEqual({ lorem: 'ipsum' })
       expect(localStorage.setItem).toHaveBeenCalledWith(
         key,
         JSON.stringify({ lorem: 'ipsum' }),
@@ -175,7 +174,7 @@ describe('default', () => {
       await nextTick()
 
       //* assert
-      expect(readLocalStoage('mock')).toEqual({ lorem: 'ipsum' })
+      expect(readLocalStorage('mock')).toEqual({ lorem: 'ipsum' })
       expect(localStorage.setItem).toHaveBeenCalledWith(
         'mock',
         JSON.stringify({ lorem: 'ipsum' }),
@@ -223,7 +222,7 @@ describe('default', () => {
       await nextTick()
 
       //* assert
-      expect(readLocalStoage(key)).toEqual({
+      expect(readLocalStorage(key)).toEqual({
         lorem: 'ipsum',
         dolor: { consectetur: { adipiscing: 'elit' } },
       })
@@ -422,7 +421,7 @@ describe('default', () => {
       useStore()
 
       //* assert
-      expect(spy).toHaveBeenCalledWith(error)
+      expect(spy).toHaveBeenCalledWith('[PiniaPluginPersistedState] ', error)
     })
 
     it('error logs persistence errors', async () => {
@@ -450,7 +449,7 @@ describe('default', () => {
       await nextTick()
 
       //* assert
-      expect(spy).toHaveBeenCalledWith(error)
+      expect(spy).toHaveBeenCalledWith('[PiniaPluginPersistedState] ', error)
     })
   })
 

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -6,6 +6,6 @@ export function initializeLocalStorage(
   localStorage.setItem(key, JSON.stringify(state))
 }
 
-export function readLocalStoage(key: string): Record<string, unknown> {
+export function readLocalStorage(key: string): Record<string, unknown> {
   return JSON.parse(localStorage.getItem(key) ?? '{}')
 }


### PR DESCRIPTION
Minor: Added a global key option

## Description

### Major

1. A need to trigger points to persist data in storage. An operation in my app updates the state multiple times but the data is required to be persisted only once the operation finished. Hence for performance reasons, storing the data on $subscribe is not good.
2. For the above to work a method has also been exposed to trigger the storage updation manually from inside the store

#### Minor
1. A global option for `key` is added which can be used to have a consistent naming convention for all the store modules persisting data in an app. Example can be to always prefix the key names
2.  Created a common util `consoleError` to log errors to console with a tag.

## Linked Issues


## Additional context

I have updated the docs as well but not fully confident on the clarity of it and variable/function names. Suggestions are appreciated.
