### PR TITLE
✨  Added global key option

### DIFF
--- a/docs/guide/advanced.md
+++ b/docs/guide/advanced.md
@@ -16,16 +16,29 @@ const pinia = createPinia()
 
 pinia.use(createPersistedState({
   storage: sessionStorage,
+  key: ( { $id } ) => `_persist_${$id}`
 }))
 ```
 
 In this example, every store declaring `persist: true` will by default persist data to `sessionStorage`.
 
 Available global options include:
+- `key`
 - [`storage`](/guide/config#storage)
 - [`serializer`](/guide/config#serializer)
 - [`beforeRestore`](/guide/config#beforeRestore)
 - [`afterRestore`](/guide/config#afterRestore)
+
+<br>
+
+### Global `key` option
+- **type**: `(store: PiniaPluginContext['store']) => string`
+- **default**: `undefined`.
+
+<br>
+
+A global method to set keys for any store persistence. Useful to prefix the name of the key of each persistence of any store.
+
 
 :::info
 Any option passed to a store's `persist` configuration will override its counterpart declared in the global options.

--- a/src/core/normalize.ts
+++ b/src/core/normalize.ts
@@ -10,11 +10,16 @@ function isObject(v: unknown) {
 export default function normalizeOptions(
   options: boolean | PersistedStateOptions | undefined,
   factoryOptions: PersistedStateFactoryOptions,
+  globalOrDefaultKey?: string,
 ): PersistedStateOptions {
   options = isObject(options) ? options : Object.create(null)
 
   return new Proxy(options as object, {
     get(target, key, receiver) {
+      if (key === 'key') {
+        return Reflect.get(target, key, receiver) || globalOrDefaultKey
+      }
+
       return (
         Reflect.get(target, key, receiver) ||
         Reflect.get(factoryOptions, key, receiver)

--- a/src/core/plugin.ts
+++ b/src/core/plugin.ts
@@ -38,17 +38,22 @@ export function createPersistedState(
   factoryOptions: PersistedStateFactoryOptions = {},
 ): PiniaPlugin {
   return (context: PiniaPluginContext) => {
-    const {
-      options: { persist },
-      store,
-    } = context
+    const { options, store } = context
+    const { persist } = options
+    let globalOrDefaultKey = store.$id
 
     if (!persist) return
 
+    if (typeof factoryOptions.key === 'function') {
+      globalOrDefaultKey = factoryOptions.key(store)
+    }
+
     const persistences = (
       Array.isArray(persist)
-        ? persist.map(p => normalizeOptions(p, factoryOptions))
-        : [normalizeOptions(persist, factoryOptions)]
+        ? persist.map(p =>
+            normalizeOptions(p, factoryOptions, globalOrDefaultKey),
+          )
+        : [normalizeOptions(persist, factoryOptions, globalOrDefaultKey)]
     ).map(
       ({
         storage = localStorage,
@@ -58,7 +63,7 @@ export function createPersistedState(
           serialize: JSON.stringify,
           deserialize: JSON.parse,
         },
-        key = store.$id,
+        key = globalOrDefaultKey,
         paths = null,
         debug = false,
       }) => ({

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -59,10 +59,17 @@ export interface PersistedStateOptions {
   debug?: boolean
 }
 
-export type PersistedStateFactoryOptions = Pick<
-  PersistedStateOptions,
-  'storage' | 'serializer' | 'afterRestore' | 'beforeRestore' | 'debug'
->
+export interface PersistedStateFactoryOptions
+  extends Pick<
+    PersistedStateOptions,
+    'storage' | 'serializer' | 'afterRestore' | 'beforeRestore' | 'debug'
+  > {
+  /**
+   * Storage key to globally for all modules. Priority will be given to store level key in `persist`
+   * @default undefined
+   */
+  key?: (store: PiniaPluginContext['store']) => string
+}
 
 declare module 'pinia' {
   export interface DefineStoreOptionsBase<S extends StateTree, Store> {


### PR DESCRIPTION
## Description

A global option for key is added which can be used to have a consistent naming convention for all the store modules persisting data in an app. Example can be to always prefix the key names

## Linked Issues

https://github.com/prazdevs/pinia-plugin-persistedstate/issues/131


## Additional context

