### PR TITLE
✨Added option to manually update storage for persisted data

### DIFF
--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -64,6 +64,20 @@ export type PersistedStateFactoryOptions = Pick<
   'storage' | 'serializer' | 'afterRestore' | 'beforeRestore' | 'debug'
 >
 
+export type PersistenceHydrator = (opts?: { runHooks?: boolean }) => void
+
+export type PersistanceStorageUpdater = (state: StateTree) => void
+
+export type PersitenceOperationsCache<T> = Record<
+  PiniaPluginContext['store']['$id'],
+  Array<T>
+>
+
+export type DefineStorePersistOption =
+  | boolean
+  | PersistedStateOptions
+  | PersistedStateOptions[]
+
 declare module 'pinia' {
   export interface DefineStoreOptionsBase<S extends StateTree, Store> {
     /**
@@ -75,10 +89,30 @@ declare module 'pinia' {
 
   export interface PiniaCustomProperties {
     /**
-     * Rehydrates store from persisted state
-     * Warning: this is for advances usecases, make sure you know what you're doing.
-     * @see https://github.com/prazdevs/pinia-plugin-persistedstate
+     * @deprecated use `$persist.hydrate` instead
      */
     $hydrate: (opts?: { runHooks?: boolean }) => void
+
+    $persist: {
+      /**
+       * Manually updates storage with the persisted state
+       * @see https://github.com/prazdevs/pinia-plugin-persistedstate
+       * @param {number} [persistanceIndex=-1] - the index of the persistence you want to hydrate store from. `-1` will update for all
+       */
+      updateStorage: (persistanceIndex?: number) => void
+
+      /**
+       * Rehydrates store from persisted state
+       * Warning: this is for advances usecases, make sure you know what you're doing.
+       * @see https://github.com/prazdevs/pinia-plugin-persistedstate
+       * @param {number} [persistanceIndex=-1] - the index of the persistence you want to hydrate store from. `-1` will update for all
+       * @param {Object} [opts]
+       * @param {boolean} [opts.runHooks] - whether to run restore hooks
+       */
+      hydrate: (
+        persistanceIndex?: number,
+        opts?: { runHooks?: boolean },
+      ) => void
+    }
   }
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,11 @@
+export const consoleError: typeof console.error = (...args) => {
+  console.error('[PiniaPluginPersistedState] ', ...args)
+}
+
+export const consoleWarn: typeof console.error = (...args) => {
+  console.warn('[PiniaPluginPersistedState] ', ...args)
+}
+
+export const consoleInfo: typeof console.error = (...args) => {
+  console.info('[PiniaPluginPersistedState] ', ...args)
+}

--- a/tests/plugin.spec.ts
+++ b/tests/plugin.spec.ts
@@ -140,7 +140,7 @@ describe('default', () => {
       //* assert
       expect(store.lorem).toEqual('')
 
-      store.$hydrate()
+      store.$persist.hydrate()
       await nextTick()
 
       expect(store.lorem).toEqual('ipsum')
@@ -422,7 +422,7 @@ describe('default', () => {
       useStore()
 
       //* assert
-      expect(spy).toHaveBeenCalledWith(error)
+      expect(spy).toHaveBeenCalledWith('[PiniaPluginPersistedState] ', error)
     })
 
     it('error logs persistence errors', async () => {
@@ -450,7 +450,7 @@ describe('default', () => {
       await nextTick()
 
       //* assert
-      expect(spy).toHaveBeenCalledWith(error)
+      expect(spy).toHaveBeenCalledWith('[PiniaPluginPersistedState] ', error)
     })
   })
 
@@ -505,7 +505,7 @@ describe('default', () => {
     // it('rehydrates from different storages', () => {})
   })
 
-  describe('$hydrate', () => {
+  describe('$persist.hydrate', () => {
     const beforeRestore = vi.fn()
     const afterRestore = vi.fn()
     const useStore = defineStore(key, {
@@ -520,7 +520,7 @@ describe('default', () => {
       await nextTick()
 
       //* act
-      store.$hydrate()
+      store.$persist.hydrate()
 
       //* assert
       expect(store.lorem).toEqual('ipsum')
@@ -537,7 +537,7 @@ describe('default', () => {
       afterRestore.mockClear()
 
       //* act
-      store.$hydrate({ runHooks: false })
+      store.$persist.hydrate(-1, { runHooks: false })
 
       //* assert
       expect(beforeRestore).not.toHaveBeenCalled()


### PR DESCRIPTION
## Description

This PR will add a method with which you can manually update the storage with the persisted state. 
Also - deprecated the `$hydrate` method and moved both of them under the `$persist` object.

## Linked Issues

https://github.com/prazdevs/pinia-plugin-persistedstate/issues/133


## Additional context
