### PR TITLE
✨ updation/hydration triggers

### DIFF
--- a/docs/guide/advanced.md
+++ b/docs/guide/advanced.md
@@ -83,9 +83,37 @@ defineStore('store', {
 In this specific case, on hydration, the data retrieved from `sessionStorage` will replace the data retrieved from `localStorage`.
 :::
 
+## Manually persist state
+
+In case you need to manually persist the data in the storage, you can access the method in the `$persist` object available in the store as `$persist.updateStorage`.
+
+```ts
+import { defineStore } from 'pinia'
+
+defineStore('store', {
+  state: () => ({
+    someData: 'Hello Pinia'
+  }),
+  action: {
+    updateSomeData( newValue ) {
+      this.someData = newValue;
+
+      this.$persist.updateStorage();
+    }
+  },
+  persist: {
+    updationTriggers: []
+  },
+})
+```
+
+When there are multiple persistences then you will need to pass the index of the persistence you want to update.
+
 ## Forcing the rehydration
 
-In case you need to manually trigger hydration from storage, every store now exposes a `$hydrate` method. By default, calling this method will also trigger the `beforeRestore` and `afterRestore` hooks. You can avoid the hooks triggering by specifying the method not to.
+In case you need to manually trigger hydration from storage, every store now exposes a `hydrate` method in the `$persist` object. By default, calling this method will also trigger the `beforeRestore` and `afterRestore` hooks. You can avoid the hooks triggering by specifying the method not to.
+
+When there are multiple persistences then you will need to pass the index of the persistence you want to update. if `-1` is passed then the store will be hydrated from all persistences.
 
 Given this store:
 
@@ -104,7 +132,7 @@ You can call `$hydrate`:
 ```ts
 const store = useStore()
 
-store.$hydrate({ runHooks: false })
+store.$persist.hydrate(-1, { runHooks: false })
 ```
 
 This will fetch data from the storage and replace the current state with it. In the example above, hooks will not be triggered.

--- a/docs/guide/config.md
+++ b/docs/guide/config.md
@@ -74,6 +74,61 @@ This store will be persisted in [`sessionStorage`](https://developer.mozilla.org
 Storage must be synchronous. More info in the [limitations page](/guide/limitations).
 :::
 
+## updationTriggers
+
+- **type**: [`Array<'subscribe' | 'beforeunload'>`]
+- **default**: [`['subscribe']`]
+
+When the data will actually be put in storage. 
+1. `subscribe`: implies that the data will be updated in storage on every `$subscribe` of the store. 
+2. `beforeunload`: implies that the data will only be updated in storage when the browser tab is refreshed/killed.
+
+When `[]` is passed then only manual updation will happen. Prefer manual updation using `$persist.updateStorage` instead of `subscribe` when the store is being updated at high frequency
+
+:::details Example
+```ts
+import { defineStore } from 'pinia'
+
+export const useStore = defineStore('store', {
+  state: () => ({
+    someState: 'hello pinia',
+  }),
+  persist: {
+    updationTriggers: [ 'beforeunload' ]
+  },
+})
+```
+
+## hydrationTriggers
+
+- **type**: [`Array<'created'>`]
+- **default**: [`['created']`]
+
+When the store will be hydrated from the data present in the storage
+1. `created`: the hydration will happen the moment the store is initialised
+
+When `[]` is passed then only manual hydration will happen. Use `$persist.hydrate` to manually hydrate. 
+
+:::details Example
+```ts
+import { defineStore } from 'pinia'
+
+export const useStore = defineStore('store', {
+  state: () => ({
+    someState: 'hello pinia',
+  }),
+  persist: {
+    hydrationTriggers: []
+  },
+
+  action: {
+    verifiedLocalStorage() {
+      this.$perist.hydrate()
+    }
+  }
+})
+```
+
 ## paths
 
 - **type**: `string[]`

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -64,6 +64,20 @@ export type PersistedStateFactoryOptions = Pick<
   'storage' | 'serializer' | 'afterRestore' | 'beforeRestore' | 'debug'
 >
 
+export type PersistenceHydrator = (opts?: { runHooks?: boolean }) => void
+
+export type PersistanceStorageUpdater = (state: StateTree) => void
+
+export type PersitenceOperationsCache<T> = Record<
+  PiniaPluginContext['store']['$id'],
+  Array<T>
+>
+
+export type DefineStorePersistOption =
+  | boolean
+  | PersistedStateOptions
+  | PersistedStateOptions[]
+
 declare module 'pinia' {
   export interface DefineStoreOptionsBase<S extends StateTree, Store> {
     /**
@@ -75,10 +89,30 @@ declare module 'pinia' {
 
   export interface PiniaCustomProperties {
     /**
-     * Rehydrates store from persisted state
-     * Warning: this is for advances usecases, make sure you know what you're doing.
-     * @see https://github.com/prazdevs/pinia-plugin-persistedstate
+     * @deprecated use `$persist.hydrate` instead
      */
     $hydrate: (opts?: { runHooks?: boolean }) => void
+
+    $persist: {
+      /**
+       * Manually updates storage with the persisted state
+       * @see https://github.com/prazdevs/pinia-plugin-persistedstate
+       * @param {number} [persistanceIndex=-1] - the index of the persistence you want to hydrate store from. `-1` will update for all
+       */
+      updateStorage: (persistanceIndex?: number) => void
+
+      /**
+       * Rehydrates store from persisted state
+       * Warning: this is for advances usecases, make sure you know what you're doing.
+       * @see https://github.com/prazdevs/pinia-plugin-persistedstate
+       * @param {number} [persistanceIndex=-1] - the index of the persistence you want to hydrate store from. `-1` will update for all
+       * @param {Object} [opts]
+       * @param {boolean} [opts.runHooks] - whether to run restore hooks
+       */
+      hydrate: (
+        persistanceIndex?: number,
+        opts?: { runHooks?: boolean },
+      ) => void
+    }
   }
 }

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -57,6 +57,21 @@ export interface PersistedStateOptions {
    * @default false
    */
   debug?: boolean
+
+  /**
+   * Defines at what points can the storage be updated.
+   * 'subscribe' - happens on every $subscribe
+   * 'beforeunload' - happens before browser tab close/refresh
+   * @default ['subscribe']
+   */
+  updationTriggers?: Array<'subscribe' | 'beforeunload'>
+
+  /**
+   * Defines at what points can the store be hydrated from the persisted data from storage
+   * `created` - hydration will happen on created
+   * @default ['created']
+   */
+  hydrationTriggers?: Array<'created'>
 }
 
 export type PersistedStateFactoryOptions = Pick<

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -9,3 +9,19 @@ export const consoleWarn: typeof console.error = (...args) => {
 export const consoleInfo: typeof console.error = (...args) => {
   console.info('[PiniaPluginPersistedState] ', ...args)
 }
+
+export function safeAttachWindowEvent(
+  eventName: keyof WindowEventMap,
+  handler: EventListener,
+  { debug }: { debug: boolean },
+): void {
+  const canAttachEvent = window && 'addEventListener' in window
+
+  if (!canAttachEvent) {
+    if (debug) consoleError('Cannot attach "beforeunload" event to window')
+
+    return
+  }
+
+  window.addEventListener(eventName, handler)
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,11 @@
+export const consoleError: typeof console.error = (...args) => {
+  console.error('[PiniaPluginPersistedState] ', ...args)
+}
+
+export const consoleWarn: typeof console.error = (...args) => {
+  console.warn('[PiniaPluginPersistedState] ', ...args)
+}
+
+export const consoleInfo: typeof console.error = (...args) => {
+  console.info('[PiniaPluginPersistedState] ', ...args)
+}

--- a/tests/plugin.spec.ts
+++ b/tests/plugin.spec.ts
@@ -140,7 +140,7 @@ describe('default', () => {
       //* assert
       expect(store.lorem).toEqual('')
 
-      store.$hydrate()
+      store.$persist.hydrate()
       await nextTick()
 
       expect(store.lorem).toEqual('ipsum')
@@ -422,7 +422,7 @@ describe('default', () => {
       useStore()
 
       //* assert
-      expect(spy).toHaveBeenCalledWith(error)
+      expect(spy).toHaveBeenCalledWith('[PiniaPluginPersistedState] ', error)
     })
 
     it('error logs persistence errors', async () => {
@@ -450,7 +450,7 @@ describe('default', () => {
       await nextTick()
 
       //* assert
-      expect(spy).toHaveBeenCalledWith(error)
+      expect(spy).toHaveBeenCalledWith('[PiniaPluginPersistedState] ', error)
     })
   })
 
@@ -505,7 +505,7 @@ describe('default', () => {
     // it('rehydrates from different storages', () => {})
   })
 
-  describe('$hydrate', () => {
+  describe('$persist.hydrate', () => {
     const beforeRestore = vi.fn()
     const afterRestore = vi.fn()
     const useStore = defineStore(key, {
@@ -520,7 +520,7 @@ describe('default', () => {
       await nextTick()
 
       //* act
-      store.$hydrate()
+      store.$persist.hydrate()
 
       //* assert
       expect(store.lorem).toEqual('ipsum')
@@ -537,7 +537,7 @@ describe('default', () => {
       afterRestore.mockClear()
 
       //* act
-      store.$hydrate({ runHooks: false })
+      store.$persist.hydrate(-1, { runHooks: false })
 
       //* assert
       expect(beforeRestore).not.toHaveBeenCalled()


### PR DESCRIPTION
## Description

This is second PR solving the same issue and should be reviewed after https://github.com/prazdevs/pinia-plugin-persistedstate/pull/134 only as it contains 1 commit from the same PR. 

This PR adds the actual triggers with which you can control when the store is hydrated as well as when the storage will be updated.

Also updates the docs for the same

## Linked Issues

https://github.com/prazdevs/pinia-plugin-persistedstate/issues/133


## Additional context

