### PR TITLE
Fixed/hmr restore

### DIFF
--- a/packages/plugin/src/plugin.ts
+++ b/packages/plugin/src/plugin.ts
@@ -68,6 +68,8 @@ export function createPersistedState(
 
     if (!persist)
       return
+    if (store.$id.startsWith('__hot:'))
+      return
 
     const persistences = (
       Array.isArray(persist)

--- a/packages/plugin/tests/plugin.spec.ts
+++ b/packages/plugin/tests/plugin.spec.ts
@@ -592,6 +592,24 @@ describe('default', () => {
       expect(readLocalStoage(key)).toEqual({ lorem: 'ipsum' })
     })
   })
+
+  describe('hmr enabled', () => {
+    const useStoreAfterHMR = defineStore(`__hot:${key}`, {
+      state: () => ({ lorem: 'ipsum', lorem_new: 'ipsum_new' }),
+      persist: true,
+    })
+
+    it('when pinia enable hmr', () => {
+      //* arrange
+      const store = useStoreAfterHMR()
+
+      //* act
+
+      //* assert
+      expect(store.$hydrate).toBeUndefined()
+      expect(store.$persist).toBeUndefined()
+    })
+  })
 })
 
 describe('w/ global options', () => {


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/prazdevs/pinia-plugin-persistedstate/blob/main/CONTRIBUTING.md).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

## Description

stop running `createPersistedState` when found with `__hot:` at start of `store.$id`

## Linked Issues

#79 


## Additional context

- for example, there is a store file with a store named `key` is enabled hmr. when it is updating, `pinia` will create a temporary store named `__hot:key`. the temporary store is lie in `pinia._s` but `pinia.state`, and it will be destoried after the file is updated. so, no state of it is needed to `$patch`.

- in our plugin, `createPersistedState` will be run when any store created, so i do to inscribe a check with `store.$id`. if it's start with `__hot:` as pinia gived, i will stop running `createPersistedState`.

- error in located in the first parameter of `mergeReactiveObjects` when running  `store.$patch`.it cannot get the success store.
[pinia-$patch](https://github.com/vuejs/pinia/blob/v2/packages/pinia/src/store.ts#LL301C50-L301C50)
