### PR TITLE
fix🐛: hmr restore error

### DIFF
--- a/packages/hmr/src/index.ts
+++ b/packages/hmr/src/index.ts
@@ -40,7 +40,11 @@ export function acceptHMRUpdateWithHydration(initialUseStore: any, hot: any) {
         if (!existingStore)
           return
 
-        useStore(pinia, existingStore).$hydrate?.()
+        const store = useStore(pinia, existingStore)
+        // persist after store is merged.
+        // the working data is really user need,
+        // so we don't need hydrate
+        store.$persist?.()
       }
     }
   }

--- a/packages/hmr/src/index.ts
+++ b/packages/hmr/src/index.ts
@@ -40,11 +40,7 @@ export function acceptHMRUpdateWithHydration(initialUseStore: any, hot: any) {
         if (!existingStore)
           return
 
-        const store = useStore(pinia, existingStore)
-        // persist after store is merged.
-        // the working data is really user need,
-        // so we don't need hydrate
-        store.$persist?.()
+        useStore(pinia, existingStore)
       }
     }
   }

--- a/packages/plugin/src/plugin.ts
+++ b/packages/plugin/src/plugin.ts
@@ -74,8 +74,17 @@ export function createPersistedState(
     /** is original store or hot store */
     const is_original = store.$id in pinia.state.value
     // if store is created as hot store, we're support to do nothing.
-    if (!is_original)
+    /* c8 ignore next 3 */
+    if (!is_original) {
+      const original_id = store.$id.replace('__hot:', '')
+      // @ts-expect-error `_s is a stripped @internal`
+      const original_store = pinia._s.get(original_id)
+      /* c8 ignore next 3 */
+      if (original_store)
+        // `$persist` original_store after anything finished
+        Promise.resolve().then(() => original_store.$persist())
       return
+    }
 
     const persistences = (
       Array.isArray(persist)

--- a/packages/plugin/src/plugin.ts
+++ b/packages/plugin/src/plugin.ts
@@ -64,9 +64,17 @@ export function createPersistedState(
     const {
       options: { persist = auto },
       store,
+      pinia,
     } = context
 
     if (!persist)
+      return
+    // if store is created when hmr, it will not be put in `pinia.state`.
+    // see https://github.com/vuejs/pinia/blob/v2/packages/pinia/src/store.ts#L265-L272.
+    /** is original store or hot store */
+    const is_original = store.$id in pinia.state.value
+    // if store is created as hot store, we're support to do nothing.
+    if (!is_original)
       return
 
     const persistences = (


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/prazdevs/pinia-plugin-persistedstate/blob/main/CONTRIBUTING.md).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

## Description

stop running `createPersistedState` for hot store

## Linked Issues

#79 


## Additional context

- for example, there is a store file with a store named `key` is enabled hmr. when it is updating, `pinia` will create a temporary store named `__hot:key`. the temporary store is lie in `pinia._s` but `pinia.state`, and it will be destoried after the file is updated. so, no state of it is needed to `$patch`.

- in our plugin, `createPersistedState` will be run when any store created, so i do to inscribe a check with `store.$id`. if it's start with `__hot:` as pinia gived, i will stop running `createPersistedState`.

- error in located in the first parameter of `mergeReactiveObjects` when running  `store.$patch`.it cannot get the success store.
[pinia-$patch](https://github.com/vuejs/pinia/blob/v2/packages/pinia/src/store.ts#LL301C50-L301C50)
