### PR TITLE
feat✨: allow to change and persist cookie before nuxt init

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "typescript.tsdk": "node_modules\\typescript\\lib"
+}

--- a/packages/nuxt/playground/app.vue
+++ b/packages/nuxt/playground/app.vue
@@ -1,6 +1,7 @@
 <script setup>
 const local = useLocalUser()
 const cookie = useCookieUser()
+const preset_cookie = usePresetCookie()
 </script>
 
 <template>
@@ -11,5 +12,9 @@ const cookie = useCookieUser()
   <div>
     <span>Cookie:</span>
     <input v-model="cookie.username">
+  </div>
+  <div>
+    <span>UserAgent:</span>
+    <input v-model="preset_cookie.token" readonly>
   </div>
 </template>

--- a/packages/nuxt/playground/composables/presetCookie.ts
+++ b/packages/nuxt/playground/composables/presetCookie.ts
@@ -1,0 +1,17 @@
+import { defineStore } from 'pinia'
+
+export const usePresetCookie = defineStore('preset-cookie', {
+  state: () => ({
+    access_token: 0,
+    refresh_token: 0,
+  }),
+  actions: {
+    setToken(token?: number) {
+      this.access_token = token ?? this.access_token + 1
+      this.refresh_token = token ?? this.refresh_token + 1
+    },
+  },
+  persist: {
+    storage: persistedState.cookies,
+  },
+})

--- a/packages/nuxt/playground/middleware/change-cookie.global.ts
+++ b/packages/nuxt/playground/middleware/change-cookie.global.ts
@@ -1,0 +1,11 @@
+/* eslint-disable no-console */
+/* eslint-disable n/prefer-global/process */
+export default defineNuxtRouteMiddleware(() => {
+  if (process.client)
+    return
+  const preset_cookie = usePresetCookie()
+  console.log(toRaw(preset_cookie.$state))
+  preset_cookie.setToken()
+  console.log(toRaw(preset_cookie.$state))
+  persistCookie(preset_cookie, ['access_token'])
+})

--- a/packages/nuxt/src/constant.ts
+++ b/packages/nuxt/src/constant.ts
@@ -1,0 +1,7 @@
+export const persisted_state = '__persisted-state'
+
+declare module 'h3' {
+  interface H3EventContext {
+    [persisted_state]?: Record<string, any>
+  }
+}

--- a/packages/nuxt/src/module.ts
+++ b/packages/nuxt/src/module.ts
@@ -1,4 +1,4 @@
-import { addImports, addPlugin, createResolver, defineNuxtModule } from '@nuxt/kit'
+import { addImports, addPlugin, addServerPlugin, createResolver, defineNuxtModule } from '@nuxt/kit'
 import { type CookieOptions } from 'nuxt/app'
 import { type NuxtModule } from 'nuxt/schema'
 import { defu } from 'defu'
@@ -36,9 +36,15 @@ export default defineNuxtModule<ModuleOptions>({
       from: resolve('./runtime/storages'),
     })
 
+    addImports({
+      name: 'persistCookie',
+      from: resolve('./runtime/persist-cookie'),
+    })
+
     // provides plugin
     nuxt.hook('modules:done', () => {
       addPlugin(resolve('./runtime/plugin'), { append: true })
+      addServerPlugin(resolve('./server/plugin'))
     })
   },
 }) satisfies NuxtModule<ModuleOptions>

--- a/packages/nuxt/src/runtime/persist-cookie.ts
+++ b/packages/nuxt/src/runtime/persist-cookie.ts
@@ -1,0 +1,12 @@
+import type { Store } from 'pinia'
+import { pick } from 'pinia-plugin-persistedstate'
+import { persisted_state } from '../constant'
+import { useRequestEvent } from '#imports'
+
+export function persistCookie(store: Store, path?: string[]) {
+  const event = useRequestEvent()
+  if (event) {
+    const cookies = event.context[persisted_state] ??= {}
+    cookies[store.$id] = path ? pick(store.$state, path) : store.$state
+  }
+}

--- a/packages/nuxt/src/server/plugin.ts
+++ b/packages/nuxt/src/server/plugin.ts
@@ -1,0 +1,11 @@
+import { persisted_state } from '../constant'
+import { defineNitroPlugin } from '#imports'
+
+export default defineNitroPlugin((nitroApp) => {
+  nitroApp.hooks.hook('render:response', (_, { event }) => {
+    const cookies = event.context[persisted_state] ?? {}
+    const id_list = Object.keys(cookies)
+    for (const id of id_list)
+      setCookie(event, id, JSON.stringify(cookies[id]))
+  })
+})

--- a/packages/nuxt/src/server/tsconfig.json
+++ b/packages/nuxt/src/server/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../playground/.nuxt/tsconfig.server.json",
+  "include": ["./", "../runtime/persist-cookie.ts"]
+}

--- a/packages/nuxt/tsconfig.json
+++ b/packages/nuxt/tsconfig.json
@@ -1,4 +1,5 @@
 {
   "extends": "./playground/.nuxt/tsconfig.json",
-  "include": ["./src"]
+  "include": ["./src"],
+  "exclude": ["./src/server"]
 }

--- a/packages/plugin/src/index.ts
+++ b/packages/plugin/src/index.ts
@@ -1,5 +1,7 @@
 import { createPersistedState } from './plugin'
 
+export { pick } from './pick'
+
 export {
   type PersistedStateOptions,
   type PersistedStateFactoryOptions,

--- a/packages/plugin/src/pick.ts
+++ b/packages/plugin/src/pick.ts
@@ -6,13 +6,10 @@ function get(state: StateTree, path: Array<string>): unknown {
   }, state)
 }
 
+const ProtoRE = /^(__proto__)$/
 function set(state: StateTree, path: Array<string>, val: unknown): StateTree {
   return (
-    (path.slice(0, -1).reduce((obj, p) => {
-      if (/^(__proto__)$/.test(p))
-        return {}
-      else return (obj[p] = obj[p] || {})
-    }, state)[path[path.length - 1]] = val),
+    (path.slice(0, -1).reduce((obj, p) => ProtoRE.test(p) ? {} : (obj[p] ||= {}), state)[path.at(-1)!] = val),
     state
   )
 }


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/prazdevs/pinia-plugin-persistedstate/blob/main/CONTRIBUTING.md).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

## Description

when opening a page on bowser, nuxt will be initialized and generate a html as response. if you are doing some thing like `useStore` and change store with nuxt's plugin, it will not persist state because there is no nuxt instance.

so, I make a new nitro plugin to make sure the initialize connection can obtain data of cookies from client side, and set cookies after pinia store is changed.

but the problem that our plugin is not able to get nuxt instance is still unresolved, so I provided a method to tell the plugin what to pass.

## Linked Issues

#221 


## Additional context

maybe we need to test how it work after many revision
