### PR TITLE
fix: persist is not initialized

### DIFF
--- a/packages/plugin/src/plugin.ts
+++ b/packages/plugin/src/plugin.ts
@@ -121,6 +121,7 @@ export function createPersistedState(
         if (runHooks)
           beforeRestore?.(context)
 
+        persistState(store.$state, persistence)
         hydrateStore(store, persistence)
 
         if (runHooks)


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/prazdevs/pinia-plugin-persistedstate/blob/main/CONTRIBUTING.md).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

## Description
If it is in the store, even if a state has a default value, if the change has not been triggered (because the setItem of the storage has not been triggered), `persist` will not take effect.
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

## Linked Issues
fix: #255 
<!-- Reference the issues this PR solves -->


## Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
