### PR TITLE
fix: persist is not initialized

### DIFF
--- a/packages/plugin/src/plugin.ts
+++ b/packages/plugin/src/plugin.ts
@@ -24,12 +24,15 @@ interface Persistence {
 
 function hydrateStore(
   store: Store,
-  { storage, serializer, key, debug }: Persistence,
+  persistence: Persistence,
 ) {
+  const { storage, serializer, key, debug } = persistence
   try {
     const fromStorage = storage?.getItem(key)
     if (fromStorage)
       store.$patch(serializer?.deserialize(fromStorage))
+    else
+      persistState(store.$state, persistence)
   }
   catch (error) {
     if (debug)


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/prazdevs/pinia-plugin-persistedstate/blob/main/CONTRIBUTING.md).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

## Description
If there is a store, even if a certain state has a default value, persist will not take effect if it has not been changed (because the setItem of the storage has not been triggered).

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

## Linked Issues

<!-- Reference the issues this PR solves -->

fix: #255 

## Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
This initialization will occur in the `hydrateStore`, by calling `persistState`
