### PR TITLE
🔥 hydrate store using paths

### DIFF
--- a/packages/plugin/src/plugin.ts
+++ b/packages/plugin/src/plugin.ts
@@ -61,12 +61,15 @@ function parsePersistence(factoryOptions: PersistedStateFactoryOptions, store: S
 
 function hydrateStore(
   store: Store,
-  { storage, serializer, key, debug }: Persistence,
+  { storage, serializer, key, paths, debug }: Persistence,
 ) {
   try {
     const fromStorage = storage?.getItem(key)
-    if (fromStorage)
-      store.$patch(serializer?.deserialize(fromStorage))
+    if (fromStorage){
+      const deserialisedStorage = serializer?.deserialize(fromStorage);
+      const hydratedObject = Array.isArray(paths) ? pick(deserialisedStorage, paths) : deserialisedStorage;
+      store.$patch(hydratedObject)
+    }
   }
   catch (e) {
     if (debug)

--- a/packages/plugin/src/plugin.ts
+++ b/packages/plugin/src/plugin.ts
@@ -21,6 +21,7 @@ interface Persistence {
   key: string
   paths: string[] | null
   debug: boolean
+  pathHydration: boolean
   beforeRestore?: (c: PiniaPluginContext) => void
   afterRestore?: (c: PiniaPluginContext) => void
 }
@@ -39,6 +40,7 @@ function parsePersistence(factoryOptions: PersistedStateFactoryOptions, store: S
         key = store.$id,
         paths = null,
         debug = false,
+        pathHydration = false
       } = o
 
       return {
@@ -49,6 +51,7 @@ function parsePersistence(factoryOptions: PersistedStateFactoryOptions, store: S
         key: (factoryOptions.key ?? (k => k))(typeof key == 'string' ? key : key(store.$id)),
         paths,
         debug,
+        pathHydration
       }
     }
     catch (e) {
@@ -61,13 +64,13 @@ function parsePersistence(factoryOptions: PersistedStateFactoryOptions, store: S
 
 function hydrateStore(
   store: Store,
-  { storage, serializer, key, paths, debug }: Persistence,
+  { storage, serializer, key, paths, debug, pathHydration }: Persistence,
 ) {
   try {
     const fromStorage = storage?.getItem(key)
     if (fromStorage){
       const deserialisedStorage = serializer?.deserialize(fromStorage);
-      const hydratedObject = Array.isArray(paths) ? pick(deserialisedStorage, paths) : deserialisedStorage;
+      const hydratedObject = pathHydration && Array.isArray(paths) ? pick(deserialisedStorage, paths) : deserialisedStorage;
       store.$patch(hydratedObject)
     }
   }

--- a/packages/plugin/src/types.ts
+++ b/packages/plugin/src/types.ts
@@ -59,6 +59,12 @@ export interface PersistedStateOptions {
    * @default false
    */
   debug?: boolean
+
+  /**
+   * Only hydrate store with values present in `paths`
+   * @default false
+   */
+  pathHydration?: boolean
 }
 
 export type PersistedStateFactoryOptions = Prettify<Pick<


### PR DESCRIPTION
## Description

Currently the plugin will restore the entire contents of localStorage or sessionStorage back into the Vue store, regardless of which paths are whitelisted by the `paths` array. This can result in stale data from a user being put back into the store which should no longer be persisted (i.e in the past the field was included in the `paths` array but has since been removed) or potentially allows a bad actor to inject their own data into the Vue store (granted this is slightly contrived but _could_ be an issue for some applications).

## Linked Issues

#268 

## Additional context

This has been tested (via Jest) and also locally in my own app. Unsure if we want this to be turned on/off via a config option?
