### PR TITLE
fix: configuration error described in the README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Nuxt support comes out of the box thanks to the included module. You just need t
 export default defineNuxtConfig({
   modules: [
     '@pinia/nuxt', // required
-    'pinia-plugin-persistedstate/nuxt',
+    '@pinia-plugin-persistedstate/nuxt',
   ],
 })
 ```


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/prazdevs/pinia-plugin-persistedstate/blob/main/CONTRIBUTING.md).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

## Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

The introduction to the Nuxt configuration in the README file at the root directory of the project source code contains errors. This took me some time to discover because I initially configured it according to the instructions in the README.

## Linked Issues

<!-- Reference the issues this PR solves -->

No issues, and I don't think it's necessary to create an issue for this, because once the problem is fixed, it won't occur again. Additionally, this is a low-probability issue.

## Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
