### PR TITLE
fix(nuxt): check has pinia module

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -48,7 +48,7 @@ export default defineNuxtModule<ModuleOptions>({
     const resolver = createResolver(import.meta.url)
     const logger = useLogger()
 
-    if (!hasNuxtModule('@pinia/nuxt', nuxt)) {
+    if (!hasNuxtModule('pinia', nuxt)) {
       logger.warn('The `@pinia/nuxt` module was not found, `pinia-plugin-persistedstate/nuxt` will not work.')
       return
     }


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/prazdevs/pinia-plugin-persistedstate/blob/main/CONTRIBUTING.md).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

## Description

This PR fixes an issue that occurs when a Nuxt module adds another module internally.

For example, if you add the following in a Nuxt module:

```js
installModule('@pinia/nuxt')
installModule('pinia-plugin-persistedstate/nuxt')
```

It triggers the following error:
```
The `@pinia/nuxt` module was not found, `pinia-plugin-persistedstate/nuxt` will not work.
```

This issue arises due to the way the `hasNuxtModule function operates:

```js
function hasNuxtModule(moduleName, nuxt = useNuxt()) {
  return nuxt.options._installedModules.some(({ meta }) => meta.name === moduleName) || // check modules to be installed
  nuxt.options.modules.some((m) => moduleName === resolveNuxtModuleEntryName(m))
}
```

The meta name of `@pinia/nuxt` is always `pinia` in `_installedModules`. `@pinia/nuxt` is only present in `nuxt.options.modules` when declared in the nuxt.config


The root of the problem lies in the `meta.name` property. For @pinia/nuxt, its `meta.name` is always pinia in ` nuxt.options._installedModules`. However, @pinia/nuxt is only present in `nuxt.options.modules` when explicitly declared in nuxt.config.

To reproduce the issue, check this Stackblitz example:

https://stackblitz.com/edit/github-ymapkt?file=src%2Fmodule.ts

