### PR TITLE
docs: fix import syntax in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Nuxt support comes out of the box thanks to the included module. You just need t
 export default defineNuxtConfig({
   modules: [
     '@pinia/nuxt', // required
-    'pinia-plugin-persistedstate/nuxt',
+    '@pinia-plugin-persistedstate/nuxt',
   ],
 })
 ```


### PR DESCRIPTION

<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/prazdevs/pinia-plugin-persistedstate/blob/main/CONTRIBUTING.md).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

## Description

This PR fixes a missing `@` in the import statement within the Nuxt usage example in the README.

## Linked Issues

None.

## Additional context

This is a minor documentation update to improve clarity for Nuxt users.
