### PR TITLE
fix: Fixes typing in Store when connecting

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,13 +45,14 @@ pinia.use(piniaPluginPersistedstate)
 3. Add the `persist` option to the store you want to be persisted:
 
 ```ts
+import type { PersistType } from 'pinia-plugin-persistedstate'
 import { defineStore } from 'pinia'
 
 export const useStore = defineStore('store', {
   state: () => ({
     someState: 'hello pinia',
   }),
-  persist: true,
+  persist: true satisfies PersistType,
 })
 ```
 
@@ -67,7 +68,7 @@ export const useStore = defineStore('store', () => {
   persist: {
     storage: sessionStorage,
     pick: ['someState'],
-  },
+  } satisfies PersistType,
 })
 ```
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,5 @@
 import type { Path } from 'deep-pick-omit'
-import type { PiniaPluginContext, StateTree } from 'pinia'
+import type { PiniaPluginContext, StateTree, Store } from 'pinia'
 
 /**
  * Synchronous storage based on Web Storage API.

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,5 @@
 import type { Path } from 'deep-pick-omit'
-import type { PiniaPluginContext, StateTree, Store } from 'pinia'
+import type { PiniaPluginContext, StateTree } from 'pinia'
 
 /**
  * Synchronous storage based on Web Storage API.
@@ -82,6 +82,8 @@ export interface Persistence<State extends StateTree = StateTree> {
 
 export type PersistenceOptions<State extends StateTree = StateTree> = Partial<Persistence<State>>
 
+export type PersistType = boolean | PersistenceOptions<StateTree> | PersistenceOptions<StateTree>[]
+
 declare module 'pinia' {
   // eslint-disable-next-line unused-imports/no-unused-vars
   export interface DefineStoreOptionsBase<S extends StateTree, Store> {
@@ -89,7 +91,7 @@ declare module 'pinia' {
      * Persist store in storage
      * @see https://prazdevs.github.io/pinia-plugin-persistedstate
      */
-    persist?: boolean | PersistenceOptions<S> | PersistenceOptions<S>[]
+    persist?: PersistType
   }
 
   export interface PiniaCustomProperties {


### PR DESCRIPTION
# Description

When pinia-plugin-persistedstate is connected - stor types are broken.

The problem is that the type used is not imported.

This PR fixes this error.

![image](https://github.com/user-attachments/assets/f2f5a325-e6d5-4111-86fb-ee80e586ee43)

